### PR TITLE
fix: proper heuristics match loop conditioning

### DIFF
--- a/lua/rocks-config/init.lua
+++ b/lua/rocks-config/init.lua
@@ -27,7 +27,7 @@ function rocks_config.setup(user_configuration)
 
             local ok, err = pcall(require, search)
 
-            if not ok and type(err) ~= "boolean" and not err:match("module%s+." .. search:gsub("%p", "%%%1") .. ".%s+not%s+found") then
+            if not ok and type(err) == "string" and not err:match("module%s+." .. search:gsub("%p", "%%%1") .. ".%s+not%s+found") then
                 error(err)
             end
         end

--- a/lua/rocks-config/init.lua
+++ b/lua/rocks-config/init.lua
@@ -27,10 +27,8 @@ function rocks_config.setup(user_configuration)
 
             local ok, err = pcall(require, search)
 
-            if not ok and not err:match("module%s+." .. search:gsub("%p", "%%%1") .. ".%s+not%s+found") then
+            if not ok and type(err) ~= "boolean" and not err:match("module%s+." .. search:gsub("%p", "%%%1") .. ".%s+not%s+found") then
                 error(err)
-            else
-                break
             end
         end
     end


### PR DESCRIPTION
For some reason, Lua's `break` was causing issues with the plugins configuration loading when the first heuristic didn't match at all, causing the two remaining heuristics to not be checked