### PR TITLE
feat: add `options` table

### DIFF
--- a/lua/rocks-config/init.lua
+++ b/lua/rocks-config/init.lua
@@ -76,6 +76,12 @@ function rocks_config.setup(user_configuration)
     if type(config.config.colorscheme or config.config.colourscheme) == "string" then
         pcall(vim.cmd.colorscheme, config.config.colorscheme or config.config.colourscheme)
     end
+
+    if type(config.config.options) == "table" then
+        for key, value in pairs(config.config.options) do
+            vim.opt[key] = value
+        end
+    end
 end
 
 return rocks_config


### PR DESCRIPTION
`rocks-config.nvim` is a general Neovim configuration suite including plugins.

This small code snippet allows a `[config.options]` to be provided to set neovim options.

An interesting complement for this feature would be https://github.com/nvim-neorocks/rocks.nvim/issues/240