### PR TITLE
feat: add plugin bundles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 format:
-	stylua -v --verify lua/rocks-config/ plugin/
+	stylua -v --verify lua/rocks-config/
 
 check:
-	luacheck lua/rocks-config plugin/
+	luacheck lua/rocks-config

--- a/README.md
+++ b/README.md
@@ -116,6 +116,13 @@ require('lualine').setup {
 options = { icons_enabled = true, theme = "auto" }
 ```
 
+The `config` field can also take on the form of a string pointing to a Lua module (if you would
+like to execute a one-off script in a different location to the global `plugins_dir` option):
+```toml
+# rocks.toml
+[plugins.lualine]
+config = "plugins.statusline" # Will execute `.config/nvim/lua/plugins/statusline.lua`
+```
 #### `auto_setup`
 
 Some plugins that don't work without a `setup` call,
@@ -150,6 +157,49 @@ or `require("rocks").packadd("<rock-name")`[^6].
 
 [^5]: See `:h rocks.commands`
 [^6]: See `:h rocks.lua`
+
+## Plugin Bundles
+
+Apart from configuration on a per-plugin basis, it's also possible to create collections of plugins
+(called bundles) and configure them all in one go.
+
+Below is an example that bundles LSP-related plugins together:
+```toml
+[plugins]
+"neodev.nvim"= "scm"
+nvim-lspconfig = { version = "0.1.7" } 
+
+[plugins.nvim-cmp]
+git = "hrsh7th/nvim-cmp" # Use the git version of nvim-cmp for the best experience.
+
+[bundles.lsp] # Create a bundle called `lsp`
+items = [
+    "neodev.nvim",
+    "nvim-lspconfig",
+    "nvim-cmp"
+]
+```
+
+Now, instead of invoking each individual configuration file for each plugin separately,
+`rocks-config.nvim` will instead look for a `lua/plugins/lsp.lua` file which it will execute.
+You can then place your setup code for *all three* plugins in the same file.
+
+#### `config`
+
+Similarly to regular plugins, a `config` field can be applied to a bundle. This `config`
+field can only be a string pointing to an alternative Lua module to execute. Example:
+```toml
+[bundles.lsp] # Create a bundle called `lsp`
+items = [
+    "neodev.nvim",
+    "nvim-lspconfig",
+    "nvim-cmp"
+]
+config = "bundles.language_support"
+```
+
+Instead of looking inside `lua/plugins/lsp.lua`, `rocks-config.nvim` will now search for
+a file in `lua/bundles/language_support.lua`.
 
 ## :book: License
 

--- a/lua/rocks-config/init.lua
+++ b/lua/rocks-config/init.lua
@@ -99,21 +99,53 @@ function rocks_config.setup(user_configuration)
     if type(config.bundles) == "table" then
         for bundle_name, bundle in pairs(config.bundles) do
             if type(bundle) == "table" and type(bundle.items) == "table" then
+                local nonexistent_bundle_item = vim.iter(bundle.items):find(function(item)
+                    return user_configuration.plugins[item] == nil
+                end)
+
+                if nonexistent_bundle_item then
+                    vim.notify(
+                        string.format(
+                            "[rocks-config.nvim]: Bundle '%s' has invalid plugin '%s'. Did you make a typo, or is the plugin not installed?",
+                            bundle_name,
+                            nonexistent_bundle_item
+                        ),
+                        vim.log.levels.ERROR
+                    )
+                    goto continue
+                end
+
                 if type(bundle.config) ~= "nil" and type(bundle.config) ~= "string" then
-                    vim.notify(string.format("[rocks-config.nvim]: Bundle '%s' has invalid `config` variable. Expected string pointing to a valid path, got %s instead...", bundle_name, type(bundle.config)), vim.log.levels.ERROR)
+                    vim.notify(
+                        string.format(
+                            "[rocks-config.nvim]: Bundle '%s' has invalid `config` variable. Expected string pointing to a valid path, got %s instead...",
+                            bundle_name,
+                            type(bundle.config)
+                        ),
+                        vim.log.levels.ERROR
+                    )
                     bundle.config = nil
                 end
 
-                local mod_name = bundle.config ~= nil and bundle.config or table.concat({ config.config.plugins_dir, bundle_name }, ".")
+                local mod_name = bundle.config ~= nil and bundle.config
+                    or table.concat({ config.config.plugins_dir, bundle_name }, ".")
 
                 if try_load_config(mod_name) then
                     for _, plugin in ipairs(bundle.items) do
                         exclude[plugin] = true
                     end
                 else
-                    vim.notify(string.format("[rocks-config.nvim]: Bundle '%s' has no specified configuration file, falling back to loading plugins from the bundle individually...", bundle_name), vim.log.levels.WARN)
+                    vim.notify(
+                        string.format(
+                            "[rocks-config.nvim]: Bundle '%s' has no specified configuration file, falling back to loading plugins from the bundle individually...",
+                            bundle_name
+                        ),
+                        vim.log.levels.WARN
+                    )
                 end
             end
+
+            ::continue::
         end
     end
 


### PR DESCRIPTION
This pull request implements the concept of "plugin bundles", i.e. collections of plugins that can be batched together under a single name (as well as a single configuration file).

Currently bundles take on the following form:
```toml
[plugins]
yada = "dev"
yadayada = "dev"
foobar = "dev"

[bundles]
mybundle.items = [
    "yada",
    "yadayada",
    "foobar",
]
```

If a `lua/plugins/mybundle.lua` is supplied, the setup will only be executed for that bundle and individual `yada.lua`, `yadayada.lua` and `foobar.lua` files will be ignored (open to discussion on this one).

TODOs:
- [x] Make `bundles.mybundle = []`  `bundles.mybundle.items = []` instead, as we might want to apply extra metadata to a bundle (e.g. the location of the configuration file or `config = false`).

Open to discussion about any part of the design :)