### PR TITLE
feat: detect duplicate configs and warn user

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,10 +84,6 @@ and load it if one is found.
 [^2]: For example, a config file for a plugin called `nvim-foo` could be named `foo.lua`.
 [^3]: For example, a config file for a plugin called `foo.bar` could be named `foo-bar.lua`.
 
-If more than one is found, the first one is loaded, and
-`rocks-config` will warn the user that a duplicate configuration
-was found and skipped.
-
 If you uninstall a plugin, you can leave its config (e.g. in case
 you would like to reinstall it later), and it will not cause any
 problems.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ auto_setup = false
 #### `plugins_dir`
 
 The subdirectory (relative to `nvim/lua`, default: `plugins`)
-to search for plugin configs. You can add a `lua/plugins/` directory 
+to search for plugin configs. You can add a `lua/plugins/` directory
 to your `nvim` config, with a lua script for each plugin.
 
 ```sh
@@ -83,6 +83,10 @@ and load it if one is found.
 [^1]: For example, a config file for a plugin called `foo.nvim` could be named `foo.lua`.
 [^2]: For example, a config file for a plugin called `nvim-foo` could be named `foo.lua`.
 [^3]: For example, a config file for a plugin called `foo.bar` could be named `foo-bar.lua`.
+
+If more than one is found, the first one is loaded, and
+`rocks-config` will warn the user that a duplicate configuration
+was found and skipped.
 
 If you uninstall a plugin, you can leave its config (e.g. in case
 you would like to reinstall it later), and it will not cause any

--- a/lua/rocks-config/health.lua
+++ b/lua/rocks-config/health.lua
@@ -1,0 +1,28 @@
+local health = {}
+
+local function check_for_duplicates()
+    vim.health.start("Checking for duplicate configuration files")
+
+    local dupes = require("rocks-config").duplicate_configs_found
+
+    if #dupes == 0 then
+        vim.health.ok("No duplicate configurations found.")
+        return
+    end
+
+    for _, dupe in ipairs(dupes) do
+        local plugin_name, config_basename = unpack(dupe)
+        vim.health.warn(
+            ("Duplicate configuration found for plugin '%s' named '%s.lua'. Skipping."):format(
+                plugin_name,
+                config_basename
+            )
+        )
+    end
+end
+
+function health.check()
+    check_for_duplicates()
+end
+
+return health

--- a/lua/rocks-config/health.lua
+++ b/lua/rocks-config/health.lua
@@ -13,7 +13,7 @@ local function check_for_duplicates()
     for _, dupe in ipairs(dupes) do
         local plugin_name, config_basename = unpack(dupe)
         vim.health.warn(
-            ("Duplicate configuration found for plugin '%s' named '%s.lua'. Skipping."):format(
+            ("Duplicate configuration found for plugin '%s' in file '%s.lua'. Skipping."):format(
                 plugin_name,
                 config_basename
             )

--- a/lua/rocks-config/init.lua
+++ b/lua/rocks-config/init.lua
@@ -38,9 +38,6 @@ end
 ---@param mod_name string The module name to search for
 ---@return function | nil
 local function try_get_loader_for_module(mod_name)
-    -- Loaders that search `package.preload` and `package.path`.
-    -- We don't need to search the cpath or neovim's runtimepath,
-    -- as the nvim `lua` directory is added to the `package.path`.
     for _, searcher in ipairs(package.loaders) do
         local loader = searcher(mod_name)
 
@@ -55,7 +52,7 @@ end
 ---Emulates Lua's require mechanism behaviour. Lua's `require` function
 ---returns `true` if the module returns nothing (`nil`), so we do the same.
 ---@param loader function The loader function
----@return any loaded
+---@return unknown loaded
 local function load_like_require(loader)
     local module = loader()
 
@@ -91,13 +88,14 @@ end
 ---Checks if a plugin that already had a configuration loaded has
 ---a given duplicate candidate configuration, and warns the user.
 ---@param plugin_name string The plugin that is being configured
+---@param config_basename string The basename of the configuration module.
 ---@param mod_name string The configuration module name to check for
-local function check_for_duplicate(plugin_name, match_name, mod_name)
+local function check_for_duplicate(plugin_name, config_basename, mod_name)
     local duplicate = try_get_loader_for_module(mod_name)
 
     if duplicate ~= nil then
         vim.notify(
-            ("Duplicate configuration found for plugin '%s' named '%s.lua'. Skipping."):format(plugin_name, match_name),
+            ("Duplicate configuration found for plugin '%s' named '%s.lua'. Skipping."):format(plugin_name, config_basename),
             vim.log.levels.WARN
         )
     end

--- a/lua/rocks-config/init.lua
+++ b/lua/rocks-config/init.lua
@@ -95,7 +95,10 @@ local function check_for_duplicate(plugin_name, config_basename, mod_name)
 
     if duplicate ~= nil then
         vim.notify(
-            ("Duplicate configuration found for plugin '%s' named '%s.lua'. Skipping."):format(plugin_name, config_basename),
+            ("Duplicate configuration found for plugin '%s' named '%s.lua'. Skipping."):format(
+                plugin_name,
+                config_basename
+            ),
             vim.log.levels.WARN
         )
     end

--- a/lua/rocks-config/init.lua
+++ b/lua/rocks-config/init.lua
@@ -151,6 +151,13 @@ function rocks_config.setup(user_configuration)
     if type(config.config.colorscheme or config.config.colourscheme) == "string" then
         pcall(vim.cmd.colorscheme, config.config.colorscheme or config.config.colourscheme)
     end
+
+    if #rocks_config.duplicate_configs_found > 0 then
+        vim.notify(
+            "Issues found while loading plugin configs. Run :checkhealth rocks-config for more info.",
+            vim.log.levels.WARN
+        )
+    end
 end
 
 return rocks_config

--- a/lua/rocks-config/init.lua
+++ b/lua/rocks-config/init.lua
@@ -86,7 +86,8 @@ local function try_load_config(mod_name)
 end
 
 ---Checks if a plugin that already had a configuration loaded has
----a given duplicate candidate configuration, and warns the user.
+---a given duplicate candidate configuration, and registers the duplicate
+---for being checked later.
 ---@param plugin_name string The plugin that is being configured
 ---@param config_basename string The basename of the configuration module.
 ---@param mod_name string The configuration module name to check for
@@ -94,17 +95,13 @@ local function check_for_duplicate(plugin_name, config_basename, mod_name)
     local duplicate = try_get_loader_for_module(mod_name)
 
     if duplicate ~= nil then
-        vim.notify(
-            ("Duplicate configuration found for plugin '%s' named '%s.lua'. Skipping."):format(
-                plugin_name,
-                config_basename
-            ),
-            vim.log.levels.WARN
-        )
+        table.insert(rocks_config.duplicate_configs_found, { plugin_name, config_basename })
     end
 end
 
 function rocks_config.setup(user_configuration)
+    rocks_config.duplicate_configs_found = {}
+
     if not user_configuration or type(user_configuration) ~= "table" then
         return
     end


### PR DESCRIPTION
This pull request is an attempt at duplicate configuration detection and warning as I suggested in #30.

This uses `vim.notify` with a level of `WARN`. I thought about implementing this as a health check, but the only options I could think of were:
- Having a module-level duplicates list which I could append to, and later check on `health.lua`.
- Redoing the whole lookup on `health.lua`.

I'd prefer the first one, and I don't find it too terrible since I don't think it would ever make sense to run this plugin twice. However it would be a bigger change, involves some global state, and I'd like some feedback on the idea before going down that route.