### PR TITLE
feat: avoid crashing and log errors

### DIFF
--- a/lua/rocks-config/health.lua
+++ b/lua/rocks-config/health.lua
@@ -1,9 +1,30 @@
 local health = {}
 
+local rocks_config = require("rocks-config")
+
+local function check_for_load_errors()
+    vim.health.start("Checking for errors while loading configs")
+
+    local errors = rocks_config.failed_to_load
+
+    if #errors == 0 then
+        vim.health.ok("No configuration errors.")
+        return
+    end
+
+    for _, dupe in ipairs(errors) do
+        local plugin_name, config_basename, error = unpack(dupe)
+        vim.health.error(
+            ("Error while loading config '%s.lua' for plugin '%s'."):format(config_basename, plugin_name),
+            { ("Error was: %s"):format(error) }
+        )
+    end
+end
+
 local function check_for_duplicates()
     vim.health.start("Checking for duplicate configuration files")
 
-    local dupes = require("rocks-config").duplicate_configs_found
+    local dupes = rocks_config.duplicate_configs_found
 
     if #dupes == 0 then
         vim.health.ok("No duplicate configurations found.")
@@ -22,6 +43,7 @@ local function check_for_duplicates()
 end
 
 function health.check()
+    check_for_load_errors()
     check_for_duplicates()
 end
 

--- a/lua/rocks-config/init.lua
+++ b/lua/rocks-config/init.lua
@@ -117,7 +117,9 @@ local function load_config(plugin_name, config_basename, mod_name)
     end
 
     if type(result) ~= "boolean" then
-        error("try_load_config did not return boolean as expected.")
+        error(
+            "rocks-config.nvim: The impossible happened! Please report this bug: try_load_config did not return boolean as expected."
+        )
     end
 
     return result
@@ -126,7 +128,7 @@ end
 ---Check if any errors were registered during setup.
 ---@return boolean
 local function errors_found()
-    return #rocks_config.duplicate_configs_found > 0 and #rocks_config.failed_to_load > 0
+    return #rocks_config.duplicate_configs_found > 0 or #rocks_config.failed_to_load > 0
 end
 
 function rocks_config.setup(user_configuration)


### PR DESCRIPTION
This avoids crashing `rocks-config.nvim` if a config file has an error. Right now, if any plugin configuration fails, everything that comes after it won't run. E.g.: Let's say I have an error on my `lualine.nvim` config. Then I don't even have my LSP configured to edit the file and fix it :(

Errors are logged in `:checkhealth` and the specific information about the error is added as advice:

![image_2024-04-18_16-00-00](https://github.com/nvim-neorocks/rocks-config.nvim/assets/774694/fee2e38f-ccfb-4c02-bc38-d8715215fa38)

