### PR TITLE
feat: support new rocks.nvim preload hook API

### DIFF
--- a/lua/rocks-config/rocks/hooks/preload.lua
+++ b/lua/rocks-config/rocks/hooks/preload.lua
@@ -9,9 +9,12 @@ plugins_dir = "plugins/"
 ```
 --]]
 
-if vim.g.rocks_config_nvim_loaded then
-    return
-end
 vim.g.rocks_config_nvim_loaded = true
 
-require("rocks-config.internal").setup()
+---@type rocks.hooks.Action
+return {
+    type = "Action",
+    hook = function()
+        require("rocks-config.internal").setup()
+    end,
+}


### PR DESCRIPTION
See https://github.com/nvim-neorocks/rocks.nvim/pull/392 (will need to be merged first, so we can update the flake.lock here).

Note: This is backward compatible, so we don't need to bump the minimum required rocks.nvim version.