### PR TITLE
feat: vim help docs

### DIFF
--- a/doc/rocks-config.nvim.txt
+++ b/doc/rocks-config.nvim.txt
@@ -1,0 +1,227 @@
+*rocks-config.nvim.txt*       Allow rocks.nvim to help configure your plugins.
+
+<https://luarocks.org/modules/neorocks/rocks-config.nvim>
+
+
+SUMMARY                                            *rocks-config.nvim-summary*
+
+`rocks-config.nvim` extends `rocks.nvim`
+<https://github.com/nvim-neorocks/rocks-config.nvim> with the ability to
+configure your plugins.
+
+
+INSTALLATION                                  *rocks-config.nvim-installation*
+
+Simply run `:Rocks install rocks-config.nvim`, and you are good to go!
+
+
+USAGE                                                *rocks-config.nvim-usage*
+
+With this extension, you can add a `[config]` table to your `rocks.toml`, for
+example:
+
+>toml
+    [plugins]
+    "neorg" = "7.0.0"
+    "sweetie.nvim" = "1.0.0"
+    
+    [config]
+    plugins_dir = "plugins/"
+    auto_setup = false
+<
+
+
+OPTIONS ~
+
+
+PLUGINS_DIR
+
+The subdirectory (relative to `nvim/lua`, default: `plugins`) to search for
+plugin configs. You can add a `lua/plugins/` directory to your `nvim` config,
+with a lua script for each plugin.
+
+>sh
+    ── nvim
+      ├── lua
+      │  └── plugins # Your plugin configs go here.
+      │     └── neorg.lua
+      │     └── sweetie.lua # or sweetie-nvim.lua
+      ├── init.lua
+<
+
+Upon startup, for each plugin in the `rocks.toml`’s `[plugins]` table, this
+module will search for a matching config module in and load it if one is found.
+
+
+  [!NOTE]
+  Possible config file names are:
+  - The plugin’s name (as long as it is a valid module name).
+  - The plugin’s name with the `.[n]vim` suffix removed.
+  - The plugin’s name with the `[n]vim-` prefix removed.
+  - The plugin’s name with `"-"` substituted for `"."`.
+If you uninstall a plugin, you can leave its config (e.g. in case you would
+like to reinstall it later), and it will not cause any problems.
+
+
+<PLUGIN>.CONFIG - ADDING BASIC CONFIGURATIONS TO ROCKS.TOML
+
+Many Neovim plugins require a call to a `setup` function, which typically takes
+a configuration table. If none of the configuration options are lua functions,
+you can add the config to your rocks.toml, and this plugin will automatically
+call `setup` with the plugin’s options.
+
+For example, the following lua configuration:
+
+>lua
+    -- lua/plugins/lualine.lua
+    require('lualine').setup {
+      options = {
+        icons_enabled = true,
+        theme = 'auto',
+      },
+    }
+<
+
+…can also be configured via rocks.toml:
+
+>toml
+    # rocks.toml
+    [plugins.lualine.config]
+    options = { icons_enabled = true, theme = "auto" }
+<
+
+The `config` field can also take on the form of a string pointing to a Lua
+module (if you would like to execute a one-off script in a different location
+to the global `plugins_dir` option):
+
+>toml
+    # rocks.toml
+    [plugins.lualine]
+    config = "plugins.statusline" # Will execute `.config/nvim/lua/plugins/statusline.lua`
+<
+
+
+AUTO_SETUP
+
+Some plugins that don’t work without a `setup` call, even if you are happy
+with the default options. `rocks-config.nvim` provides a hack to work around
+this with the `auto_setup` option (disabled by default). If enabled, and no
+config is found for an installed plugin, this module will attempt to call
+`require('<plugin-name>').setup()` for you.
+
+
+  [!WARNING]
+  Enabling `auto_setup` could lead to unexpected behaviour. For example, if a
+  plugin that doesn’t need a `setup` call has configuration/initialization
+  logic in its main module, it will be invoked with the call to `require`,
+  potentially resulting in more eager initialization than necessary.
+You can also enable/disable `auto_setup` for individual plugins by setting
+`config = true` or `config = false`, respectively.
+
+
+INITIALIZATION ORDER ~
+
+rocks.nvim makes use of Neovim’s built-in |initialization sequence|, and
+provides a hook that rocks-config.nvim uses to load configs _before_ any plugin
+scripts are sourced.
+
+If you need to source a plugin’s scripts eagerly (for example, to load
+colorschemes), you can set the plugin’s `opt = true` in rocks.toml, and then
+load it with `vim.cmd.Rocks({"packadd", "<rock-name>"})` or
+`require("rocks").packadd("<rock-name")`.
+
+
+PLUGIN BUNDLES                              *rocks-config.nvim-plugin-bundles*
+
+Apart from configuration on a per-plugin basis, it’s also possible to create
+collections of plugins (called bundles) and configure them all in one go.
+
+Below is an example that bundles LSP-related plugins together:
+
+>toml
+    [plugins]
+    "neodev.nvim"= "scm"
+    nvim-lspconfig = { version = "0.1.7" } 
+    
+    [plugins.nvim-cmp]
+    git = "hrsh7th/nvim-cmp" # Use the git version of nvim-cmp for the best experience.
+    
+    [bundles.lsp] # Create a bundle called `lsp`
+    items = [
+        "neodev.nvim",
+        "nvim-lspconfig",
+        "nvim-cmp"
+    ]
+<
+
+Now, instead of invoking each individual configuration file for each plugin
+separately, `rocks-config.nvim` will instead look for a `lua/plugins/lsp.lua`
+file which it will execute. You can then place your setup code for _all three_
+plugins in the same file.
+
+
+CONFIG
+
+Similarly to regular plugins, a `config` field can be applied to a bundle. This
+`config` field can only be a string pointing to an alternative Lua module to
+execute. Example:
+
+>toml
+    [bundles.lsp] # Create a bundle called `lsp`
+    items = [
+        "neodev.nvim",
+        "nvim-lspconfig",
+        "nvim-cmp"
+    ]
+    config = "bundles.language_support"
+<
+
+Instead of looking inside `lua/plugins/lsp.lua`, `rocks-config.nvim` will now
+search for a file in `lua/bundles/language_support.lua`.
+
+
+LOAD_OPT_PLUGINS
+
+By default, `rocks-config.nvim` will not load configs for plugins with `opt =
+true` or plugins that have been marked as `opt`, e.g. by rocks-lazy.nvim. You
+can either override this behaviour by setting `load_opt_plugins = true`, or you
+can load the config for a plugin using the `configure(name)` function:
+
+>lua
+    require("rocks-config").configure("foo.nvim")
+    vim.cmd.packadd("foo.nvim")
+<
+
+
+NEOVIM CONFIGURATION                  *rocks-config.nvim-neovim-configuration*
+
+You can also use `rocks-config.nvim` to set various Neovim options in your
+rocks.toml.
+
+Here is an example:
+
+>toml
+    [config]
+    colorscheme = "kanagawa"
+    
+    [config.options]
+    number = true
+    relativenumber = true
+    hlsearch = true
+    completeopt = 'menu,menuone,noinsert,fuzzy,preview,noselect'
+    # ...
+<
+
+
+LICENSE                                            *rocks-config.nvim-license*
+
+`rocks-config.nvim` is licensed under GPLv3 <./LICENSE>.
+
+==============================================================================
+1. Links                                             *rocks-config.nvim-links*
+
+1. *LuaRocks*: https://img.shields.io/luarocks/v/neorocks/rocks-config.nvim?logo=lua&color=purple&style=for-the-badge
+
+Generated by panvimdoc <https://github.com/kdheepak/panvimdoc>
+
+vim:tw=78:ts=8:noet:ft=help:norl:

--- a/flake.nix
+++ b/flake.nix
@@ -80,6 +80,12 @@
             stylua.enable = true;
             luacheck.enable = true;
             editorconfig-checker.enable = true;
+            panvimdoc = {
+              enable = true;
+              name = "panvimdoc";
+              entry = "${pkgs.panvimdoc}/bin/panvimdoc --project-name rocks-config.nvim --toc false --treesitter true --demojify true --description ' Allow rocks.nvim to help configure your plugins.' --input-file";
+              files = "README.md";
+            };
           };
         };
       in {


### PR DESCRIPTION
This is a quick panvimdoc setup so that users can access the documentation with `:h rocks-config`.